### PR TITLE
Bedrock connector

### DIFF
--- a/marker/services/bedrock.py
+++ b/marker/services/bedrock.py
@@ -72,7 +72,6 @@ class BedrockService(BaseService):
         max_retries: int | None = 0,
         timeout: int | None = None,
     ):
-        print("called")
         schema_example = response_schema.model_json_schema()
         system_prompt = f"""
 Follow the instructions given by the user prompt.  You must provide your response in JSON format matching this schema:

--- a/marker/services/bedrock.py
+++ b/marker/services/bedrock.py
@@ -94,7 +94,7 @@ Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  
             }
         ]
 
-        # logger.info(f"\prompt: {prompt}\n")
+        # logger.info(f"\nprompt: {prompt}\n")
         prompt_config = prompt_config = {
             "anthropic_version": "bedrock-2023-05-31",
             "max_tokens": self.max_tokens,
@@ -123,7 +123,7 @@ Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  
                     )
                 # Extract response
                 response_text = response_body.get("content")[0].get("text")
-                logger.info(f"\nresponse: {response_text}\n")
+                # logger.info(f"\nresponse: {response_text}\n")
                 return self.validate_response(response_text, response_schema)
             except Exception as e:
                 logger.error(f"Error during Bedrock API call: {e}")

--- a/marker/services/bedrock.py
+++ b/marker/services/bedrock.py
@@ -73,6 +73,7 @@ class BedrockService(BaseService):
         timeout: int | None = None,
     ):
         schema_example = response_schema.model_json_schema()
+        # logger.info(schema_example)
         system_prompt = f"""
 Follow the instructions given by the user prompt.  You must provide your response in JSON format matching this schema:
 
@@ -93,6 +94,7 @@ Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  
             }
         ]
 
+        # logger.info(f"\prompt: {prompt}\n")
         prompt_config = prompt_config = {
             "anthropic_version": "bedrock-2023-05-31",
             "max_tokens": self.max_tokens,
@@ -121,7 +123,7 @@ Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  
                     )
                 # Extract response
                 response_text = response_body.get("content")[0].get("text")
-                # logger.info(f"response: {response_text}")
+                logger.info(f"\nresponse: {response_text}\n")
                 return self.validate_response(response_text, response_schema)
             except Exception as e:
                 logger.error(f"Error during Bedrock API call: {e}")

--- a/marker/services/bedrock.py
+++ b/marker/services/bedrock.py
@@ -1,8 +1,10 @@
 # %%
-import boto3
 import json
-import base64
-from PIL import Image
+from typing import Annotated, List
+
+import boto3
+import PIL
+from pydantic import BaseModel
 
 from marker.schema.blocks import Block
 from marker.services import BaseService
@@ -12,8 +14,78 @@ from marker.services import BaseService
 class BedrockService(BaseService):
     bedrock_model_name: Annotated[
         str, "The name of the Bedrock model to use for the service."
-    ] = "anthropic.claude-3-7-sonnet-20250219-v1:0"
-    bedrock_profile: Annotated[str, "Relevant AWS profile name"] = None
+    ] = "anthropic.claude-3-sonnet-20240229-v1:0"
+    bedrock_profile: Annotated[str, "Relevant AWS profile name"] = ""
+    region: Annotated[str, "AWS region name"] = "eu-west-2"
     max_tokens: Annotated[
         int, "The maximum number of tokens to use for a single request."
     ] = 8192
+
+    def process_images(self, images: List[PIL.Image.Image]) -> List[dict]:
+        """Process images so they can be included in input prompt."""
+        return [
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/webp",
+                    "data": self.img_to_base64(img),
+                },
+            }
+            for img in images
+        ]
+
+    def get_client(self):
+        """Initialise bedrock client."""
+
+        bedrock_session = boto3.session.Session(profile_name=self.bedrock_profile)
+        return bedrock_session.client(service_name="bedrock-runtime")
+
+    def __call__(
+        self,
+        prompt: str,
+        image: PIL.Image.Image | List[PIL.Image.Image] | None,
+        block: Block | None,
+        response_schema: type[BaseModel],
+        max_retries: int | None = None,
+        timeout: int | None = None,
+    ):
+        print("called")
+        schema_example = response_schema.model_json_schema()
+        system_prompt = f"""
+Follow the instructions given by the user prompt.  You must provide your response in JSON format matching this schema:
+
+{json.dumps(schema_example, indent=2)}
+
+Respond only with the JSON schema, nothing else.  Do not include ```json, ```,  or any other formatting.
+""".strip()
+
+        client = self.get_client()
+        image_data = self.format_image_for_llm(image)
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    *image_data,
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ]
+        total_tries = max_retries + 1
+        for tries in range(1, total_tries + 1):
+            print(tries)
+            try:
+                response = client.messages.create(
+                    system=system_prompt,
+                    model=self.bedrock_model_name,
+                    max_tokens=self.max_tokens,
+                    messages=messages,
+                    timeout=timeout,
+                )
+                # Extract and validate response
+                response_text = response.content[0].text
+                return response_text
+            except Exception as e:
+                print(f"Error during Bedrock API call: {e}")
+                break

--- a/sandbox.py
+++ b/sandbox.py
@@ -18,12 +18,14 @@ llm_service = "--llm_service=marker.services.bedrock.BedrockService"
 llm_model = ""  # "--ollama_model=minicpm-v:8b"
 
 # %%
-file = "/notebooks/marker/pdf.pdf"
+file = "/notebooks/marker/sample-tables.pdf"
 
 command = (
     f"marker_single {file} --output_dir {output_dir} --force_ocr"
     f"{format_lines} "
     f"{use_llm} {llm_service} {llm_model}"
+    "--bedrock_profile personal"
+    "--debug"
 )
 print(command)
 
@@ -48,9 +50,11 @@ def img_to_base64(img: PIL.Image.Image):
 base64_string = img_to_base64(Image.open("a.png"))
 
 # %%
+system_prompt = "All your output must be pirate speech"
 prompt_config = {
     "anthropic_version": "bedrock-2023-05-31",
     "max_tokens": 4096,
+    "system": system_prompt,
     "messages": [
         {
             "role": "user",
@@ -70,7 +74,7 @@ prompt_config = {
     "temperature": 0.2,
 }
 
-bedrock_session = boto3.session.Session(profile_name="personal")
+bedrock_session = boto3.session.Session(profile_name="publicprocurement_production")
 
 bedrock_runtime = bedrock_session.client(service_name="bedrock-runtime")
 
@@ -89,5 +93,8 @@ results = response_body.get("content")[0].get("text")
 
 # %%
 results
+
+# %%
+response_body.get("usage").get("output_tokens")
 
 # %%

--- a/sandbox.py
+++ b/sandbox.py
@@ -1,0 +1,93 @@
+# %%
+import os
+import PIL
+from PIL import Image
+import boto3
+import json
+from io import BytesIO
+import base64
+
+# %%
+# run script to convert files
+# it's easier to run in command line as script already done
+output_dir = "sample/"
+workers = 4
+format_lines = ""  # "--format_lines"
+use_llm = "--use_llm"
+llm_service = "--llm_service=marker.services.bedrock.BedrockService"
+llm_model = ""  # "--ollama_model=minicpm-v:8b"
+
+# %%
+file = "/notebooks/marker/pdf.pdf"
+
+command = (
+    f"marker_single {file} --output_dir {output_dir} --force_ocr"
+    f"{format_lines} "
+    f"{use_llm} {llm_service} {llm_model}"
+)
+print(command)
+
+# %%
+os.system(command)
+
+# %%
+bedrock_runtime = boto3.client(
+    service_name="bedrock-runtime",
+    region_name="eu-west-2",
+)
+
+
+# %%
+def img_to_base64(img: PIL.Image.Image):
+    image_bytes = BytesIO()
+    img.save(image_bytes, format="WEBP")
+    return base64.b64encode(image_bytes.getvalue()).decode("utf-8")
+
+
+# %%
+base64_string = img_to_base64(Image.open("a.png"))
+
+# %%
+prompt_config = {
+    "anthropic_version": "bedrock-2023-05-31",
+    "max_tokens": 4096,
+    "messages": [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/jpeg",
+                        "data": base64_string,
+                    },
+                },
+                {"type": "text", "text": "what is this image?"},
+            ],
+        }
+    ],
+    "temperature": 0.2,
+}
+
+bedrock_session = boto3.session.Session(profile_name="personal")
+
+bedrock_runtime = bedrock_session.client(service_name="bedrock-runtime")
+
+body = json.dumps(prompt_config)
+
+response = bedrock_runtime.invoke_model(
+    body=body,
+    modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+    accept="application/json",
+    contentType="application/json",
+)
+
+response_body = json.loads(response.get("body").read())
+
+results = response_body.get("content")[0].get("text")
+
+# %%
+results
+
+# %%

--- a/sandbox.py
+++ b/sandbox.py
@@ -1,11 +1,5 @@
 # %%
 import os
-import PIL
-from PIL import Image
-import boto3
-import json
-from io import BytesIO
-import base64
 
 # %%
 # run script to convert files
@@ -13,88 +7,26 @@ import base64
 output_dir = "sample/"
 workers = 4
 format_lines = ""  # "--format_lines"
-use_llm = "--use_llm"
-llm_service = "--llm_service=marker.services.bedrock.BedrockService"
+use_llm = ""  # "--use_llm"
+llm_service = ""  # "--llm_service=marker.services.bedrock.BedrockService"
 llm_model = ""  # "--ollama_model=minicpm-v:8b"
+profile = ""
 
 # %%
-file = "/notebooks/marker/sample-tables.pdf"
+file = "/notebooks/marker/Online_choice_architecture_discussion_paper.pdf"
 
 command = (
-    f"marker_single {file} --output_dir {output_dir} --force_ocr"
+    f"marker_single {file} --output_dir {output_dir} "
+    # "--force_ocr "
     f"{format_lines} "
-    f"{use_llm} {llm_service} {llm_model}"
-    "--bedrock_profile personal"
-    "--debug"
+    f"{use_llm} {llm_service} {llm_model} "
+    f"--bedrock_profile {profile} "
+    "--debug "
+    " --output_format markdown"
 )
 print(command)
 
 # %%
 os.system(command)
-
-# %%
-bedrock_runtime = boto3.client(
-    service_name="bedrock-runtime",
-    region_name="eu-west-2",
-)
-
-
-# %%
-def img_to_base64(img: PIL.Image.Image):
-    image_bytes = BytesIO()
-    img.save(image_bytes, format="WEBP")
-    return base64.b64encode(image_bytes.getvalue()).decode("utf-8")
-
-
-# %%
-base64_string = img_to_base64(Image.open("a.png"))
-
-# %%
-system_prompt = "All your output must be pirate speech"
-prompt_config = {
-    "anthropic_version": "bedrock-2023-05-31",
-    "max_tokens": 4096,
-    "system": system_prompt,
-    "messages": [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "image",
-                    "source": {
-                        "type": "base64",
-                        "media_type": "image/jpeg",
-                        "data": base64_string,
-                    },
-                },
-                {"type": "text", "text": "what is this image?"},
-            ],
-        }
-    ],
-    "temperature": 0.2,
-}
-
-bedrock_session = boto3.session.Session(profile_name="publicprocurement_production")
-
-bedrock_runtime = bedrock_session.client(service_name="bedrock-runtime")
-
-body = json.dumps(prompt_config)
-
-response = bedrock_runtime.invoke_model(
-    body=body,
-    modelId="anthropic.claude-3-sonnet-20240229-v1:0",
-    accept="application/json",
-    contentType="application/json",
-)
-
-response_body = json.loads(response.get("body").read())
-
-results = response_body.get("content")[0].get("text")
-
-# %%
-results
-
-# %%
-response_body.get("usage").get("output_tokens")
 
 # %%

--- a/sandbox.py
+++ b/sandbox.py
@@ -1,3 +1,19 @@
+# %% [markdown]
+# ### Test Bedrock connector
+#
+# Connector is in `marker/services/bedrock.py`
+#
+# This notebook will extract text from a single pdf file. To run it:
+#
+# 1. You will need an insecure GPU instance (e.g. g5).
+# 2. You'll need to first install marker using `poetry install`.
+# 3. Replace the file with a pdf file you want to test.
+# 4. Replace the parameters below. If you want to run without LLM for comparison/benchmarking, repace all llm parameters with an empty string. You can also change the LLM model, it defaults to Claude 3. The profile is required for the LLM to run, you will need to use an AWS profile with permission to access Bedrock.
+#
+# If you want to get some logs about what the LLM is doing, `bedrock.py` contains some commented logger lines that can return the prompt, the schema and the output of the LLM. You can uncomment them, restart the kernel and rerun the notebook. The log will include the pydantic schema in json, the prompt as it appears in the processor modules, and the output of the LLM, including a corrected version of the input and its rationale for the change.
+#
+# The `--force_ocr` parameter will convert all the pdf to image and perform OCR, ignoring any text already in the pdf. Uncomment the parameter if you want to try it.
+
 # %%
 import os
 
@@ -5,24 +21,21 @@ import os
 # run script to convert files
 # it's easier to run in command line as script already done
 output_dir = "sample/"
-workers = 4
-format_lines = ""  # "--format_lines"
-use_llm = ""  # "--use_llm"
-llm_service = ""  # "--llm_service=marker.services.bedrock.BedrockService"
-llm_model = ""  # "--ollama_model=minicpm-v:8b"
+use_llm = "--use_llm"
+llm_service = "--llm_service=marker.services.bedrock.BedrockService"
+llm_model = ""  # "--bedrock_profile=anthropic.claude-3-sonnet-20240229-v1:0"
 profile = ""
 
 # %%
-file = "/notebooks/marker/Online_choice_architecture_discussion_paper.pdf"
+file = "/notebooks/marker/sample-tables-single.pdf"
 
 command = (
     f"marker_single {file} --output_dir {output_dir} "
     # "--force_ocr "
-    f"{format_lines} "
     f"{use_llm} {llm_service} {llm_model} "
     f"--bedrock_profile {profile} "
     "--debug "
-    " --output_format markdown"
+    "--output_format markdown"
 )
 print(command)
 

--- a/sandbox.py
+++ b/sandbox.py
@@ -13,6 +13,8 @@
 # If you want to get some logs about what the LLM is doing, `bedrock.py` contains some commented logger lines that can return the prompt, the schema and the output of the LLM. You can uncomment them, restart the kernel and rerun the notebook. The log will include the pydantic schema in json, the prompt as it appears in the processor modules, and the output of the LLM, including a corrected version of the input and its rationale for the change.
 #
 # The `--force_ocr` parameter will convert all the pdf to image and perform OCR, ignoring any text already in the pdf. Uncomment the parameter if you want to try it.
+#
+# The `--debug` flag will generate images for each page of the pdf, indicating how the page was segmented in blocks and how those blocks have been labelled. This is really useful for debugging so I recommend having it activated. It will still generate the normal output in markdown.
 
 # %%
 import os


### PR DESCRIPTION
PR includes:
- Connector to AWS Bedrock.
- A sandbox notebook to test the connector.

How it works:
Marker will split the document in different blocks, and it will label them based on their format (text, table, header, etc.). These are processed using the modules in `marker/processors`. When using the `--use_llm` argument, it will pass the processed text from each block to the selected LLM, using the modules in `marker/processors/llm`. 

Each type of block will have a different prompt, instructing the LLM to compare the input (extracted text in html) with an image of the block, to return details about the differences between both, and if needed to return a corrected version of the html. The LLM is also instructed to return the output using a pydantic schema, which is also included in the `marker/processors/llm` files. If you want to see how the document is segmented in blocks, use the `--debug` mode when extracting text.

The connector handles the call to Bedrock. It will prepare the body of the request as required by Bedrock, and inject the prompt and the image. It includes some system prompt instructing the LLM to follow the schema for the output which I took from the Claude connector, but I'm not sure if this will be needed for newer versions of Claude.

Marker will generate some metadata in the output folder ({filename}__meta.json), which will include data such as the number of LLM calls, and which calls failed. Failures may be dure to the LLM returning a malformed output. There may be instances where the LLM returns "no corrections needed", in which case the output should not change.


**Once this is merged, we will need to replace the pip version of marker with the fork version in our environments.**

Also note we can update this fork by merging it with the original repo, but this may break our changes. We might want to consider suggesting including this connector in the original repo.